### PR TITLE
Fix faltmarke positioning

### DIFF
--- a/letter.html
+++ b/letter.html
@@ -117,7 +117,7 @@
 		top: 87mm;
 	}
 
-	#faltmarke1 {
+	#faltmarke2 {
 		top: 192mm;
 	}
 

--- a/letter.html
+++ b/letter.html
@@ -99,7 +99,6 @@
 
 	.faltmarke {
 		position: absolute;
-		top: 87mm;
 		left: 0;
 		width: 10mm;
 		border-color: black;


### PR DESCRIPTION
Visually it does not change anything, because faltmarke1 was positioned at the intended location of faltmarke2 and faltmarke2 was just located at the default faltmarke position (taking the intended position of faltmarke1).

But I think it's cleaner this way ;)